### PR TITLE
Upgrade to Ryzen AI SW 1.7

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test RyzenAI Server
-    runs-on: [rai-170-sdk, rai300_400, Windows]
+    runs-on: [rai-170-sdk, Windows]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -13,9 +13,9 @@ permissions:
   contents: write
 
 jobs:
-  build-ryzenai-server:
-    name: Build RyzenAI Server
-    runs-on: [rai-170-sdk, Windows]
+  build-and-test:
+    name: Build and Test RyzenAI Server
+    runs-on: [rai-170-sdk, rai300_400, Windows]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -119,37 +119,6 @@ jobs:
           
           $fileCount = (Get-ChildItem $releaseDir -File | Measure-Object).Count
           Write-Host "`nFound $fileCount files in release directory" -ForegroundColor Green
-          Write-Host "Contents will be uploaded as artifact (GitHub will zip automatically)" -ForegroundColor Gray
-
-      - name: Upload RyzenAI Server Package
-        uses: actions/upload-artifact@v4
-        with:
-          name: ryzenai-server
-          path: |
-            build/bin/Release/*.exe
-            build/bin/Release/*.dll
-            build/bin/Release/*.pdb
-            build/bin/Release/AMD_LICENSE
-          retention-days: 7
-
-  test-ryzenai-server:
-    name: Test RyzenAI Server
-    needs: build-ryzenai-server
-    runs-on: [rai300_400, Windows]
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: [cpu, npu, hybrid]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          clean: true
-
-      - name: Download RyzenAI Server artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ryzenai-server
-          path: build/bin/Release
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -164,16 +133,14 @@ jobs:
           python -m pip install -r test/requirements.txt
           Write-Host "Test dependencies installed!" -ForegroundColor Green
 
-      - name: Download model checkpoint
+      - name: Test all modes
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
           
           # Set HF_HOME to local directory
           $env:HF_HOME = "${{ github.workspace }}/hf_home"
-          Write-Host "HF_HOME set to: $env:HF_HOME" -ForegroundColor Cyan
           
-          # Create directory if it doesn't exist
           if (-not (Test-Path $env:HF_HOME)) {
               New-Item -ItemType Directory -Path $env:HF_HOME -Force | Out-Null
           }
@@ -185,71 +152,87 @@ jobs:
               "cpu" = "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx"
           }
           
-          $mode = "${{ matrix.mode }}"
-          $modelName = $modelMap[$mode]
+          $modes = @("cpu", "npu", "hybrid")
+          $failed = @()
           
-          Write-Host "Downloading model for $mode mode: $modelName" -ForegroundColor Cyan
-          
-          # Download the model using huggingface_hub
-          python -c @"
+          foreach ($mode in $modes) {
+              $modelName = $modelMap[$mode]
+              $logDir = "${{ github.workspace }}/test_logs"
+              
+              Write-Host "`n============================================================" -ForegroundColor Cyan
+              Write-Host "  Testing mode: $mode ($modelName)" -ForegroundColor Cyan
+              Write-Host "============================================================`n" -ForegroundColor Cyan
+              
+              # Download the model
+              Write-Host "Downloading model..." -ForegroundColor Cyan
+              python -c @"
           import os
           os.environ['HF_HOME'] = r'${{ github.workspace }}/hf_home'
-          
           from huggingface_hub import snapshot_download
-          
           model_name = '$modelName'
           print(f'Downloading {model_name}...')
-          
-          local_path = snapshot_download(
-              repo_id=model_name,
-              local_dir=None,  # Use default HF cache
-          )
-          
+          local_path = snapshot_download(repo_id=model_name, local_dir=None)
           print(f'Model downloaded to: {local_path}')
           "@
-          
-          if ($LASTEXITCODE -ne 0) {
-              Write-Host "ERROR: Failed to download model!" -ForegroundColor Red
-              exit $LASTEXITCODE
+              
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Host "ERROR: Failed to download model for $mode!" -ForegroundColor Red
+                  $failed += $mode
+                  continue
+              }
+              
+              # Run tests
+              Write-Host "Running tests for $mode..." -ForegroundColor Cyan
+              python test/test_server.py --mode $mode --server-exe build/bin/Release/ryzenai-server.exe --log-dir $logDir
+              
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Host "ERROR: Tests failed for mode $mode!" -ForegroundColor Red
+                  $failed += $mode
+              } else {
+                  Write-Host "All tests passed for mode: $mode" -ForegroundColor Green
+              }
           }
           
-          Write-Host "Model download complete!" -ForegroundColor Green
-
-      - name: Run verification tests
-        shell: PowerShell
-        run: |
-          $ErrorActionPreference = "Stop"
-          
-          # Set HF_HOME
-          $env:HF_HOME = "${{ github.workspace }}/hf_home"
-          
-          $mode = "${{ matrix.mode }}"
-          $logDir = "${{ github.workspace }}/test_logs"
-          
-          Write-Host "Running verification tests for mode: $mode" -ForegroundColor Cyan
-          Write-Host "Log directory: $logDir" -ForegroundColor Gray
-          
-          # Run the test script with log directory
-          python test/test_server.py --mode $mode --server-exe build/bin/Release/ryzenai-server.exe --log-dir $logDir
-          
-          if ($LASTEXITCODE -ne 0) {
-              Write-Host "ERROR: Tests failed for mode $mode!" -ForegroundColor Red
-              exit $LASTEXITCODE
+          # Summary
+          Write-Host "`n============================================================" -ForegroundColor Cyan
+          Write-Host "  Test Summary" -ForegroundColor Cyan
+          Write-Host "============================================================" -ForegroundColor Cyan
+          foreach ($mode in $modes) {
+              if ($failed -contains $mode) {
+                  Write-Host "  $mode : FAILED" -ForegroundColor Red
+              } else {
+                  Write-Host "  $mode : PASSED" -ForegroundColor Green
+              }
           }
+          Write-Host "============================================================`n" -ForegroundColor Cyan
           
-          Write-Host "All tests passed for mode: $mode" -ForegroundColor Green
+          if ($failed.Count -gt 0) {
+              Write-Host "ERROR: $($failed.Count) mode(s) failed: $($failed -join ', ')" -ForegroundColor Red
+              exit 1
+          }
 
       - name: Upload server logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: server-logs-${{ matrix.mode }}
+          name: server-logs
           path: ${{ github.workspace }}/test_logs/
+          retention-days: 7
+
+      - name: Upload RyzenAI Server Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ryzenai-server
+          path: |
+            build/bin/Release/*.exe
+            build/bin/Release/*.dll
+            build/bin/Release/*.pdb
+            build/bin/Release/AMD_LICENSE
           retention-days: 7
 
   create-release:
     name: Create GitHub Release
-    needs: [build-ryzenai-server, test-ryzenai-server]
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-ryzenai-server:
     name: Build RyzenAI Server
-    runs-on: [rai-160-sdk, Windows]
+    runs-on: [rai-170-sdk, Windows]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,7 +75,7 @@ jobs:
           mkdir build
           cd build
           
-          # Configure - Ryzen AI should be at C:\Program Files\RyzenAI\1.6.0
+          # Configure - Ryzen AI should be at C:\Program Files\RyzenAI\1.7.0
           cmake .. -G "Visual Studio 17 2022" -A x64
           if ($LASTEXITCODE -ne 0) { 
               Write-Host "ERROR: CMake configuration failed!" -ForegroundColor Red
@@ -180,8 +180,8 @@ jobs:
           
           # Model mapping based on mode
           $modelMap = @{
-              "npu" = "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-npu"
-              "hybrid" = "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-hybrid"
+              "npu" = "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-npu"
+              "hybrid" = "amd/Qwen2.5-0.5B-Instruct-onnx-ryzenai-1.7-hybrid"
               "cpu" = "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx"
           }
           
@@ -295,7 +295,7 @@ jobs:
             
             - Windows 11 (64-bit)
             - AMD Ryzen AI 300-series processor
-            - Ryzen AI Software 1.6.0 with LLM patch
+            - Ryzen AI Software 1.7.0
             
             ### Usage
             

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -300,7 +300,7 @@ jobs:
             ### Usage
             
             ```cmd
-            ryzenai-server.exe -m C:\path\to\onnx\model --mode hybrid
+            ryzenai-server.exe -m C:\path\to\onnx\model
             ```
             
             See the [README](https://github.com/lemonade-sdk/ryzenai-server#readme) for full documentation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(ryzenai-server VERSION 1.0.2 LANGUAGES CXX)
+project(ryzenai-server VERSION 1.7.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -17,10 +17,10 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 find_package(Threads REQUIRED)
 
 # ONNX Runtime GenAI
-set(OGA_ROOT "C:/Program Files/RyzenAI/1.6.0" CACHE PATH "Path to Ryzen AI installation")
+set(OGA_ROOT "C:/Program Files/RyzenAI/1.7.0" CACHE PATH "Path to Ryzen AI installation")
 
 if(NOT EXISTS ${OGA_ROOT})
-    message(FATAL_ERROR "Ryzen AI not found at ${OGA_ROOT}. Please install Ryzen AI 1.6.0 or set OGA_ROOT")
+    message(FATAL_ERROR "Ryzen AI not found at ${OGA_ROOT}. Please install Ryzen AI 1.7.0 or set OGA_ROOT")
 endif()
 
 message(STATUS "Using Ryzen AI from: ${OGA_ROOT}")
@@ -95,8 +95,11 @@ target_link_libraries(ryzenai-server PRIVATE
     Threads::Threads
 )
 
-# Enable multi-threading for cpp-httplib
-target_compile_definitions(ryzenai-server PRIVATE CPPHTTPLIB_THREAD_POOL_COUNT=8)
+# Pass version info from CMake to C++ as compile definitions
+target_compile_definitions(ryzenai-server PRIVATE
+    CPPHTTPLIB_THREAD_POOL_COUNT=8
+    RYZENAI_SERVER_VERSION="${PROJECT_VERSION}"
+)
 
 # Windows-specific settings
 if(WIN32)
@@ -110,13 +113,15 @@ if(WIN32)
         "${OGA_ROOT}/deployment/onnxruntime.dll"
         "${OGA_ROOT}/deployment/onnxruntime_providers_shared.dll"
         "${OGA_ROOT}/deployment/onnxruntime_providers_vitisai.dll"
+        "${OGA_ROOT}/deployment/onnxruntime_providers_ryzenai.dll"
         "${OGA_ROOT}/deployment/onnxruntime_vitisai_ep.dll"
         "${OGA_ROOT}/deployment/onnxruntime_vitis_ai_custom_ops.dll"
         "${OGA_ROOT}/deployment/onnx_custom_ops.dll"
-        "${OGA_ROOT}/deployment/abseil_dll.dll"
-        "${OGA_ROOT}/deployment/libutf8_validity.dll"
         "${OGA_ROOT}/deployment/dyn_dispatch_core.dll"
         "${OGA_ROOT}/deployment/DirectML.dll"
+        "${OGA_ROOT}/deployment/D3D12Core.dll"
+        "${OGA_ROOT}/deployment/flexmlrt.dll"
+        "${OGA_ROOT}/deployment/cert_dtrace.dll"
         "${OGA_ROOT}/deployment/zlib.dll"
         "${OGA_ROOT}/deployment/zstd.dll"
         "${OGA_ROOT}/deployment/ryzenai_onnx_utils.dll"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ This server enables running Large Language Models on AMD Ryzen AI 300-series pro
 - Windows 11 (64-bit)
 - Visual Studio 2022
 - CMake 3.20 or higher
-- **Ryzen AI Software 1.6.0** with LLM patch
-  - Base installation must be at `C:\Program Files\RyzenAI\1.6.0`
-  - LLM patch must be applied on top of base installation
+- **Ryzen AI Software 1.7.0**
+  - Default installation path: `C:\Program Files\RyzenAI\1.7.0`
   - Download from: https://ryzenai.docs.amd.com
 
 **Hardware Requirements:**
@@ -67,7 +66,7 @@ All necessary Ryzen AI DLLs are automatically copied to the output directory dur
 If Ryzen AI is installed in a custom location:
 
 ```cmd
-cmake .. -G "Visual Studio 17 2022" -A x64 -DOGA_ROOT="C:\custom\path\to\RyzenAI\1.6.0"
+cmake .. -G "Visual Studio 17 2022" -A x64 -DOGA_ROOT="C:\custom\path\to\RyzenAI\1.7.0"
 ```
 
 ## Code Structure
@@ -206,7 +205,7 @@ Returns server status and Ryzen AI-specific information:
   "model": "phi-3-mini-4k-instruct",
   "execution_mode": "hybrid",
   "max_prompt_length": 4096,
-  "ryzenai_version": "1.6.0"
+  "ryzenai_version": "1.7.0"
 }
 ```
 
@@ -269,7 +268,7 @@ print(response.choices[0].message.content)
 
 **Check:**
 1. Model path is correct and contains required ONNX files
-2. Ryzen AI 1.6.0 is installed at the correct path
+2. Ryzen AI 1.7.0 is installed at the correct path
 3. NPU drivers are up to date (Windows Update)
 4. Model is compatible with your Ryzen AI version
 
@@ -278,7 +277,7 @@ print(response.choices[0].message.content)
 All required DLLs should be automatically copied during build. If you get DLL errors:
 1. Verify Ryzen AI is installed correctly
 2. Rebuild with `cmake --build . --config Release`
-3. Manually copy DLLs from `C:\Program Files\RyzenAI\1.6.0\deployment\` to the executable directory
+3. Manually copy DLLs from `C:\Program Files\RyzenAI\1.7.0\deployment\` to the executable directory
 
 ### Port Already in Use
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ ryzenai-server/
 
 **Inference Engine:** Wraps ONNX Runtime GenAI API, managing model loading, generation parameters, and streaming callbacks. Applies chat templates and handles tool call extraction.
 
-**Execution Providers:** Supports three modes:
+**Execution Providers:** Supports three modes (auto-detected from model config):
 - **Hybrid**: NPU + iGPU
 - **NPU**: Pure NPU execution
 - **CPU**: CPU-only fallback
@@ -152,14 +152,11 @@ These dependencies must be manually installed by the developer:
 ### Starting the Server
 
 ```cmd
-# Specify NPU mode
-ryzenai-server.exe -m C:\path\to\onnx\model --mode npu
+# Start the server (execution mode is auto-detected from the model)
+ryzenai-server.exe -m C:\path\to\onnx\model
 
-# Hybrid mode with custom port
-ryzenai-server.exe -m C:\path\to\onnx\model --mode hybrid --port 8081
-
-# CPU mode
-ryzenai-server.exe -m C:\path\to\onnx\model --mode cpu
+# Custom port
+ryzenai-server.exe -m C:\path\to\onnx\model --port 8081
 
 # Verbose logging
 ryzenai-server.exe -m C:\path\to\onnx\model --verbose
@@ -170,11 +167,12 @@ ryzenai-server.exe -m C:\path\to\onnx\model --verbose
 - `-m, --model PATH` - Path to ONNX model directory (required)
 - `--host ADDRESS` - Server host address (default: 127.0.0.1)
 - `-p, --port PORT` - Server port (default: 8080)
-- `--mode MODE` - Execution mode: npu, hybrid, cpu (default: hybrid)
 - `-c, --ctx-size SIZE` - Context size in tokens (default: 2048)
 - `-t, --threads NUM` - Number of CPU threads (default: 4)
 - `-v, --verbose` - Enable verbose logging
 - `-h, --help` - Show help message
+
+The execution mode (NPU, Hybrid, or CPU) is automatically detected from the model's `genai_config.json` configuration.
 
 ### Model Requirements
 

--- a/include/ryzenai/inference_engine.h
+++ b/include/ryzenai/inference_engine.h
@@ -25,7 +25,7 @@ struct CompletionTimingData {
 
 class InferenceEngine {
 public:
-    InferenceEngine(const std::string& model_path, const std::string& mode);
+    InferenceEngine(const std::string& model_path);
     ~InferenceEngine();
     
     // Synchronous completion
@@ -57,6 +57,7 @@ private:
     void setupExecutionProvider();
     void loadRaiConfig();
     std::string detectRyzenAIVersion();
+    std::string detectExecutionMode();
     std::string resolveModelPath(const std::string& path);
     std::vector<int32_t> truncatePrompt(const std::vector<int32_t>& input_ids);
     bool validateModelDirectory(const std::string& path);

--- a/include/ryzenai/types.h
+++ b/include/ryzenai/types.h
@@ -13,7 +13,6 @@ struct CommandLineArgs {
     std::string model_path;           // -m, --model (required)
     std::string host = "127.0.0.1";   // --host
     int port = 8080;                  // --port
-    std::string mode = "hybrid";      // --mode (npu|hybrid|cpu)
     int ctx_size = 2048;              // --ctx-size
     int threads = 4;                  // --threads
     bool verbose = false;             // --verbose

--- a/src/command_line.cpp
+++ b/src/command_line.cpp
@@ -31,17 +31,6 @@ CommandLineArgs CommandLineParser::parse(int argc, char* argv[]) {
                 throw std::runtime_error("Missing value for --port");
             }
         }
-        else if (arg == "--mode") {
-            if (i + 1 < argc) {
-                args.mode = argv[++i];
-                // Validate mode
-                if (args.mode != "npu" && args.mode != "hybrid" && args.mode != "cpu") {
-                    throw std::runtime_error("Invalid mode: " + args.mode + " (must be npu, hybrid, or cpu)");
-                }
-            } else {
-                throw std::runtime_error("Missing value for --mode");
-            }
-        }
         else if (arg == "--ctx-size" || arg == "-c") {
             if (i + 1 < argc) {
                 args.ctx_size = std::stoi(argv[++i]);
@@ -74,20 +63,21 @@ CommandLineArgs CommandLineParser::parse(int argc, char* argv[]) {
 void CommandLineParser::printUsage(const char* program_name) {
     std::cout << "Ryzen AI LLM Server - OpenAI API compatible server for NPU/Hybrid/CPU execution\n\n";
     std::cout << "Usage: " << program_name << " -m MODEL_PATH [OPTIONS]\n\n";
+    std::cout << "The execution mode (NPU, Hybrid, or CPU) is auto-detected from the model's\n";
+    std::cout << "genai_config.json configuration.\n\n";
     std::cout << "Required Arguments:\n";
     std::cout << "  -m, --model PATH          Path to ONNX model directory\n\n";
     std::cout << "Optional Arguments:\n";
     std::cout << "  --host HOST               Host to bind to (default: 127.0.0.1)\n";
     std::cout << "  -p, --port PORT           Port to listen on (default: 8080)\n";
-    std::cout << "  --mode MODE               Execution mode: npu|hybrid|cpu (default: hybrid)\n";
     std::cout << "  -c, --ctx-size SIZE       Context size (default: 2048)\n";
     std::cout << "  -t, --threads NUM         Number of threads (default: 4)\n";
     std::cout << "  -v, --verbose             Enable verbose output\n";
     std::cout << "  -h, --help                Show this help message\n\n";
     std::cout << "Examples:\n";
     std::cout << "  " << program_name << " -m C:\\models\\phi-3-mini-4k-instruct-onnx\n";
-    std::cout << "  " << program_name << " -m C:\\models\\llama-2-7b-onnx --mode hybrid --port 8081\n";
-    std::cout << "  " << program_name << " -m C:\\models\\qwen-onnx --mode npu --verbose\n\n";
+    std::cout << "  " << program_name << " -m C:\\models\\llama-2-7b-onnx --port 8081\n";
+    std::cout << "  " << program_name << " -m C:\\models\\qwen-onnx --verbose\n\n";
     std::cout << "For more information, visit: https://ryzenai.docs.amd.com\n";
 }
 

--- a/src/inference_engine.cpp
+++ b/src/inference_engine.cpp
@@ -222,16 +222,10 @@ bool InferenceEngine::validateModelDirectory(const std::string& path) {
 }
 
 std::string InferenceEngine::detectRyzenAIVersion() {
-    // Check for Ryzen AI 1.6.0 installation
-    std::string ryzenai_path_16 = "C:/Program Files/RyzenAI/1.6.0";
-    if (fs::exists(ryzenai_path_16)) {
-        return "1.6.0";
-    }
-    
-    // Check for 1.5.0
-    std::string ryzenai_path_15 = "C:/Program Files/RyzenAI/1.5.0";
-    if (fs::exists(ryzenai_path_15)) {
-        return "1.5.0";
+    // Check for Ryzen AI 1.7.0 installation
+    std::string ryzenai_path_17 = "C:/Program Files/RyzenAI/1.7.0";
+    if (fs::exists(ryzenai_path_17)) {
+        return "1.7.0";
     }
     
     // Check environment variable
@@ -240,8 +234,8 @@ std::string InferenceEngine::detectRyzenAIVersion() {
         return std::string(version_env);
     }
     
-    // Default to 1.6.0
-    return "1.6.0";
+    // Default to 1.7.0
+    return "1.7.0";
 }
 
 void InferenceEngine::loadRaiConfig() {

--- a/src/inference_engine.cpp
+++ b/src/inference_engine.cpp
@@ -13,11 +13,9 @@ namespace ryzenai {
 
 namespace fs = std::filesystem;
 
-InferenceEngine::InferenceEngine(const std::string& model_path, const std::string& mode)
-    : execution_mode_(mode) {
+InferenceEngine::InferenceEngine(const std::string& model_path) {
     
     std::cout << "[InferenceEngine] Initializing with model: " << model_path << std::endl;
-    std::cout << "[InferenceEngine] Execution mode: " << mode << std::endl;
     
     // Resolve model path (handles Hugging Face cache structure)
     model_path_ = resolveModelPath(model_path);
@@ -29,6 +27,10 @@ InferenceEngine::InferenceEngine(const std::string& model_path, const std::strin
     if (!validateModelDirectory(model_path_)) {
         throw std::runtime_error("Invalid model directory: " + model_path_);
     }
+    
+    // Auto-detect execution mode from genai_config.json
+    execution_mode_ = detectExecutionMode();
+    std::cout << "[InferenceEngine] Detected execution mode: " << execution_mode_ << std::endl;
     
     // Detect Ryzen AI version and load config
     loadRaiConfig();
@@ -236,6 +238,64 @@ std::string InferenceEngine::detectRyzenAIVersion() {
     
     // Default to 1.7.0
     return "1.7.0";
+}
+
+std::string InferenceEngine::detectExecutionMode() {
+    // Auto-detect execution mode from genai_config.json by inspecting
+    // session_options in model.decoder. The key indicators are:
+    //
+    // NPU:    "hybrid_opt_token_backend": "npu" in either config_entries
+    //         or provider_options[].RyzenAI
+    // Hybrid: provider_options[].RyzenAI exists (without token_backend=npu)
+    // CPU:    empty provider_options, no config_entries
+    
+    std::string config_path = model_path_ + "/genai_config.json";
+    if (!fs::exists(config_path)) {
+        std::cout << "[InferenceEngine] No genai_config.json found, defaulting to cpu mode" << std::endl;
+        return "cpu";
+    }
+    
+    try {
+        std::ifstream file(config_path);
+        json config = json::parse(file);
+        
+        auto& session_opts = config["model"]["decoder"]["session_options"];
+        
+        // Check config_entries for hybrid_opt_token_backend == "npu"
+        if (session_opts.contains("config_entries")) {
+            auto& entries = session_opts["config_entries"];
+            if (entries.contains("hybrid_opt_token_backend") &&
+                entries["hybrid_opt_token_backend"] == "npu") {
+                return "npu";
+            }
+        }
+        
+        // Check provider_options for RyzenAI configuration
+        if (session_opts.contains("provider_options") && 
+            session_opts["provider_options"].is_array()) {
+            for (const auto& provider : session_opts["provider_options"]) {
+                if (provider.contains("RyzenAI")) {
+                    auto& ryzenai = provider["RyzenAI"];
+                    // If RyzenAI has hybrid_opt_token_backend == "npu", it's NPU
+                    if (ryzenai.contains("hybrid_opt_token_backend") &&
+                        ryzenai["hybrid_opt_token_backend"] == "npu") {
+                        return "npu";
+                    }
+                    // Otherwise RyzenAI provider present means hybrid
+                    return "hybrid";
+                }
+            }
+        }
+        
+        // No RyzenAI provider, no NPU config_entries → CPU
+        return "cpu";
+        
+    } catch (const std::exception& e) {
+        std::cerr << "[WARNING] Failed to detect execution mode from genai_config.json: " 
+                  << e.what() << std::endl;
+        std::cerr << "[WARNING] Defaulting to cpu mode" << std::endl;
+        return "cpu";
+    }
 }
 
 void InferenceEngine::loadRaiConfig() {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -143,7 +143,7 @@ void RyzenAIServer::setupRoutes() {
     http_server_->Get("/", [this](const httplib::Request&, httplib::Response& res) {
         json response = {
             {"message", "Ryzen AI LLM Server"},
-            {"version", "1.0.0"},
+            {"version", RYZENAI_SERVER_VERSION},
             {"model", model_id_},
             {"endpoints", {
                 "/health",

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -74,12 +74,10 @@ GenerationParams RyzenAIServer::createGenerationParams(int max_tokens, float tem
 void RyzenAIServer::loadModel() {
     std::cout << "[Server] Loading model..." << std::endl;
     std::cout << "[Server] Model path: " << args_.model_path << std::endl;
-    std::cout << "[Server] Execution mode: " << args_.mode << std::endl;
     
     try {
         inference_engine_ = std::make_unique<InferenceEngine>(
-            args_.model_path,
-            args_.mode
+            args_.model_path
         );
         
         model_id_ = extractModelName(args_.model_path);

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -109,8 +109,6 @@ class ServerProcess:
             self.server_exe,
             "-m",
             self.model_path,
-            "--mode",
-            self.mode,
             "--host",
             SERVER_HOST,
             "--port",

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -26,8 +26,8 @@ import openai
 
 # Model mapping for each execution mode
 MODEL_MAP = {
-    "npu": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-npu",
-    "hybrid": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-hybrid",
+    "npu": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-npu",
+    "hybrid": "amd/Qwen2.5-0.5B-Instruct-onnx-ryzenai-1.7-hybrid",
     "cpu": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
 }
 


### PR DESCRIPTION
Closes #4 

- Upgrades the build to use RAI 1.7 SDK
- Updates tests to use 1.7 models
- Removes the `--mode` flag and auto-detects npu/hybrid/cpu modes
- Streamlines the workflow to avoid an artifact download mid-Action