### PR TITLE
fix: load chat template from chat_template.jinja when available

### DIFF
--- a/src/inference_engine.cpp
+++ b/src/inference_engine.cpp
@@ -347,18 +347,35 @@ void InferenceEngine::loadModel() {
         // Create tokenizer using factory method
         tokenizer_ = OgaTokenizer::Create(*model_);
         
-        // Load chat template from tokenizer_config.json
-        std::string tokenizer_config_path = model_path_ + "/tokenizer_config.json";
-        if (fs::exists(tokenizer_config_path)) {
+        // Load chat template - prefer chat_template.jinja file over tokenizer_config.json
+        // (matches the Python reference implementation in model_chat.py)
+        std::string jinja_path = model_path_ + "/chat_template.jinja";
+        if (fs::exists(jinja_path)) {
             try {
-                std::ifstream file(tokenizer_config_path);
-                json config = json::parse(file);
-                if (config.contains("chat_template") && config["chat_template"].is_string()) {
-                    chat_template_ = config["chat_template"];
-                    std::cout << "[InferenceEngine] Loaded chat template from tokenizer_config.json" << std::endl;
-                }
+                std::ifstream file(jinja_path);
+                std::ostringstream ss;
+                ss << file.rdbuf();
+                chat_template_ = ss.str();
+                std::cout << "[InferenceEngine] Loaded chat template from chat_template.jinja" << std::endl;
             } catch (const std::exception& e) {
-                std::cerr << "[WARNING] Failed to load chat template: " << e.what() << std::endl;
+                std::cerr << "[WARNING] Failed to load chat_template.jinja: " << e.what() << std::endl;
+            }
+        }
+
+        // Fall back to tokenizer_config.json if no jinja file found
+        if (chat_template_.empty()) {
+            std::string tokenizer_config_path = model_path_ + "/tokenizer_config.json";
+            if (fs::exists(tokenizer_config_path)) {
+                try {
+                    std::ifstream file(tokenizer_config_path);
+                    json config = json::parse(file);
+                    if (config.contains("chat_template") && config["chat_template"].is_string()) {
+                        chat_template_ = config["chat_template"];
+                        std::cout << "[InferenceEngine] Loaded chat template from tokenizer_config.json" << std::endl;
+                    }
+                } catch (const std::exception& e) {
+                    std::cerr << "[WARNING] Failed to load chat template: " << e.what() << std::endl;
+                }
             }
         }
         


### PR DESCRIPTION
## Summary
- Prefer `chat_template.jinja` file from the model folder over `tokenizer_config.json` for loading chat templates
- Falls back to `tokenizer_config.json` if no jinja file is present (preserving existing behavior)
- Matches the Python reference implementation (`model_chat.py`) which already handles this correctly

## Problem
For models like `gpt-oss-20b-NPU` (and likely other MoE models), OGA's `ApplyChatTemplate` fails when using the template string from `tokenizer_config.json`:

```
[WARNING] OGA chat template failed: Invalid or unsupported chat template.
[WARNING] Using simple fallback template
```

The fallback template (`System: ... User: ... Assistant: ...`) produces garbage output because it doesn't match what the model was trained on.

Relates to lemonade-sdk/lemonade#1111

## Test plan
- [ ] Load `gpt-oss-20b-NPU` and verify chat completions produce correct output (no fallback warning)
- [ ] Load a model without `chat_template.jinja` (e.g. `chatglm3-6b-NPU`) and verify it still loads template from `tokenizer_config.json`
- [ ] Load a model with neither file and verify graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)